### PR TITLE
chore: release habitat 0.3.137

### DIFF
--- a/core/__version__.py
+++ b/core/__version__.py
@@ -2,6 +2,6 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
-VERSION = (0, 3, 136)
+VERSION = (0, 3, 137)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ DEV_REQUIRES = [
     'isort>=4.0.0,<5.0.0',
     'pytest>=4.0.0,<5.0.0',
     'pytest_httpserver==1.0.12',
-    'pex'
+    'pex==2.20.2'
 ] + REQUIRES
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
change:
1. correct the release url in standalone script. (from @zhongwuzw #2)

issue: #5