### PR TITLE
chore: improve windows compatibility

### DIFF
--- a/core/fetchers/git_fetcher.py
+++ b/core/fetchers/git_fetcher.py
@@ -259,6 +259,7 @@ class GitFetcher(Fetcher):
             for p in patch_path:
                 await apply_patches(p, source_dir)
 
+        target_dir = os.path.abspath(target_dir)
         if target_dir != source_dir and not options.raw:
             move(source_dir, target_dir)
         elif target_dir != source_dir:

--- a/core/fetchers/local_fetcher.py
+++ b/core/fetchers/local_fetcher.py
@@ -4,6 +4,7 @@
 
 import logging
 import os.path
+import platform
 import shutil
 
 from core.exceptions import HabitatException
@@ -19,7 +20,7 @@ class LocalFetcher(Fetcher):
         self.symlink = symlink
 
     async def fetch(self, *args, **kwargs):
-        disable_link = not self.symlink
+        disable_link = not self.symlink or platform.system() == 'Windows'
         if not self.reference.fetched:
             event = self.reference.parent.event_manager.register_consumer(str(self.reference.name))
             logging.debug(f'Reference component {self.reference} has not been fetched yet, waiting on event {event}')


### PR DESCRIPTION
1. not creating symlink for duplicated dependencies on Windows.
2. add a handler to shutil.rmtree for Windows permission issue.