### PR TITLE
feat: Replace empty dictionaries with DepsEnv

### DIFF
--- a/core/components/deps_env.py
+++ b/core/components/deps_env.py
@@ -1,0 +1,28 @@
+# Copyright 2025 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import platform
+
+
+class DepsEnvBuild:
+    _depsEnv = None
+
+    @staticmethod
+    def init_deps_env():
+        if DepsEnvBuild._depsEnv is None:
+            system = platform.system().lower()
+            machine = platform.machine().lower()
+            machine = "x86_64" if machine == "amd64" else machine
+            DepsEnvBuild._depsEnv = {
+                "system": system,
+                "machine": machine,
+            }
+
+    @staticmethod
+    def get_deps_env(custom={}):
+        DepsEnvBuild.init_deps_env()
+        deps_env_copy = copy.deepcopy(DepsEnvBuild._depsEnv)
+        deps_env_copy.update(custom)
+        return deps_env_copy

--- a/core/components/solution.py
+++ b/core/components/solution.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from core import __version__, components
 from core.common.error_code import ERROR_INCOMPATIBLE_VERSION
 from core.components.dependency_group import DependencyGroup
+from core.components.deps_env import DepsEnvBuild
 from core.exceptions import HabitatException
 from core.fetchers.git_fetcher import GitFetcher
 from core.settings import DEFAULT_CONFIG_FILE_NAME, DEFAULT_DEPS_CACHE_FILE_NAME, ENTRIES_CACHE_TAG_PREFIX
@@ -46,7 +47,7 @@ def load_entries_cache_from_git(root_dir=None):
 
 
 def load_solutions(root_dir, solution_file, ignore_non_existing=False, enable_version_checking=True):
-    env = {}
+    env = DepsEnvBuild.get_deps_env()
     if hasattr(solution_file, 'read'):
         exec(solution_file.read(), env)
     else:
@@ -80,7 +81,7 @@ def load_solutions(root_dir, solution_file, ignore_non_existing=False, enable_ve
 
 
 def load_mapping_file(mapping_file_path):
-    env = {}
+    env = DepsEnvBuild.get_deps_env()
     if not os.path.exists(mapping_file_path):
         return None
     with open(mapping_file_path, 'r') as f:

--- a/core/utils.py
+++ b/core/utils.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 from pathlib import Path
 from zipfile import ZipFile
 
+from core.components.deps_env import DepsEnvBuild
 from core.exceptions import HabitatException
 from core.settings import CACHE_DIR_PREFIX
 
@@ -496,7 +497,7 @@ def is_git_repo_valid(source_dir):
 
 
 def eval_deps(deps_file, target, root_dir):
-    env = {"target": target, "root_dir": root_dir}
+    env = DepsEnvBuild.get_deps_env({"target": target, "root_dir": root_dir})
     if hasattr(deps_file, 'read'):
         exec(deps_file.read(), env)
     else:


### PR DESCRIPTION
Certain constants such as `system`, `machine`, and `python_path` previously required users to implement them manually in DEPS files. Now we've built these directly into Hab's core (DepsEnv), allowing users to access these variables directly within the DEPS context.

Change-Id: If671972e6b583487d910c5d1d3961ae7593dca44