### PR TITLE
Fix: Git LFS environment variable override breaks system PATH on Windows

### DIFF
--- a/core/fetchers/git_fetcher.py
+++ b/core/fetchers/git_fetcher.py
@@ -323,9 +323,9 @@ class GitFetcher(Fetcher):
                 cmd = f"git checkout {checkout_args}"
 
             # If specify enable_lfs to false explicitly, set an extra env when running checkout command
-            checkout_env = None
+            checkout_env = os.environ.copy()
             if getattr(self.component, "enable_lfs", None) is False:
-                checkout_env = {"GIT_LFS_SKIP_SMUDGE": "1"}
+                checkout_env["GIT_LFS_SKIP_SMUDGE"] = "1"
 
             try:
                 await run_git_command(


### PR DESCRIPTION
When setting only a dictionary containing GIT_LFS_SKIP_SMUDGE as an environment variable on Windows, the system’s default environment variables are inadvertently cleared. This causes commonly used command-line tools to become unavailable, because the system PATH is overwritten and essential directories are no longer included.