### PR TITLE
fix: correct the refspec of branch-fetched git dependency

### DIFF
--- a/core/fetchers/http_fetcher.py
+++ b/core/fetchers/http_fetcher.py
@@ -73,6 +73,7 @@ def chmod_recursive(path, mode):
                 file_path = os.path.join(root, file_name)
                 os.chmod(file_path, mode)
 
+
 def on_fs_error(func, path, _):
     if not os.path.exists(str(path)):
         return


### PR DESCRIPTION
use refspec like "+refs/remotes/origin/main:refs/remotes/origin/main" to fix the failure of branch-fetched git dependency.