### PR TITLE
chore: release habitat 0.3.146

### DIFF
--- a/core/__version__.py
+++ b/core/__version__.py
@@ -2,6 +2,6 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
-VERSION = "0.3.146-alpha.4"
+VERSION = (0, 3, 146)
 
-__version__ = "0.3.146-alpha.4"
+__version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Changes:
1. fetch from cached repo instead of using alternates.
2. copy all environment variables when running git checkout.
3. recursively modify Windows file system permission when removing directories.
4. support customizing global cache directory.
5. add an option to keep action output.
6. add retry mechanism with exponential backoff to http client.
7. remove the source only when it is not the parent of the root.
8. introduce monitoring module and structural exceptions.
9. abort in-progress git am before applying patches.
10. disable recursive submodule fetching when running git fetch.