### PR TITLE
refactor(http-dependency): use merkle tree to check status

### DIFF
--- a/core/common/file_stamp.py
+++ b/core/common/file_stamp.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar, Union
+
+from core.settings import GLOBAL_CACHE_DIR
+
+
+# Write file stamp to global cache only for convenience. Make sure to add --force when executing sync command in CI
+# so that no content will be written into global cache.
+@dataclass
+class FileStamp:
+    type: str
+    name: Union[str, Path]
+    target_dir: Union[str, Path]
+
+    global_cache_dir: ClassVar[Path] = Path(GLOBAL_CACHE_DIR)
+    fast_digest: str = None
+    full_digest: str = None
+    extra: dict = None
+    version: ClassVar[int] = 1
+
+    @property
+    def stamp_path(self) -> Path:
+        buf = bytearray()
+        buf.extend((self.type + str(self.name) + str(self.target_dir)).encode("utf-8"))
+        buf.extend(json.dumps(self.extra, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        hasher = hashlib.sha256()
+        hasher.update(buf)
+        return self.global_cache_dir / f"stamps-v{self.version}" / f"{hasher.hexdigest()}.stamp"
+
+    def exists(self) -> bool:
+        return self.stamp_path.exists()
+
+    def write(self, fast_digest: str, full_digest: str):
+        self.stamp_path.parent.mkdir(parents=True, exist_ok=True)
+        obj = {
+            "version": self.version,
+            "type": self.type,
+            "name": str(self.name),
+            "target_dir": str(self.target_dir),
+            "fast_digest": fast_digest,
+            "full_digest": full_digest,
+            "extra": self.extra,
+        }
+        with open(self.stamp_path, "w") as f:
+            f.write(json.dumps(obj, indent=2))
+
+    def read(self) -> dict:
+        if not self.stamp_path.exists():
+            return {}
+
+        with open(self.stamp_path) as f:
+            content = f.read()
+
+        return json.loads(content)

--- a/core/common/hash_tree.py
+++ b/core/common/hash_tree.py
@@ -1,0 +1,129 @@
+import hashlib
+import os
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, ClassVar, Union
+
+
+class EntryType(Enum):
+    file: bytes = b"file"
+    directory: bytes = b"directory"
+    symlink: bytes = b"symlink"
+
+
+@dataclass
+class Record:
+    digest: bytes
+    name: str
+
+    digest_size: ClassVar[int] = 32
+    max_name_length: ClassVar[int] = 0xFFFF
+    header_format: ClassVar[str] = ">32sH"  # sha256 digest(32 bytes) + name_len(u16)
+    header_size: ClassVar[int] = struct.calcsize(header_format)
+
+    def pack(self) -> bytearray:
+        encoded_name = self.name.encode("utf-8")
+        encoded_size = len(encoded_name)
+
+        if encoded_size > self.max_name_length:
+            raise ValueError(f"the file name is too long: {self.name}")
+
+        if len(self.digest) != self.digest_size:
+            raise ValueError(f"digest must be {self.digest_size} bytes")
+
+        buf = bytearray(self.header_size + encoded_size)
+        struct.pack_into(self.header_format, buf, 0, self.digest, encoded_size)
+        buf[self.header_size:] = encoded_name
+        return buf
+
+
+class HashTree:
+    def __init__(
+        self,
+        hasher: Callable = hashlib.sha256,
+        chunk_size: int = 1024 * 1024,
+    ):
+        self.hasher = hasher
+        self.chunk_size = chunk_size
+
+    def hash(self, obj: Union[bytes, bytearray, Path]) -> bytes:
+        h = self.hasher()
+        if isinstance(obj, bytes) or isinstance(obj, bytearray):
+            h.update(obj)
+        elif isinstance(obj, Path):
+            with open(obj, "rb") as f:
+                for chunk in iter(lambda: f.read(self.chunk_size), b""):
+                    h.update(chunk)
+        else:
+            raise ValueError(f"object must be bytes or Path, got {type(obj)}")
+
+        return h.digest()
+
+    def __pack_record(self, child_hash: bytes, name: str) -> bytearray:
+        return Record(child_hash, name).pack()
+
+    def get_hex_digest(self, path: Path, *, full_hash: bool = True) -> str:
+        return self.get_digest(path, full_hash=full_hash).hex()
+
+    def __symlink_handler(self, path: Path):
+        # HASH(b"symlink" || symlink.target)
+        target = os.readlink(path)
+        obj = EntryType.symlink.value + target.encode("utf-8")
+        return self.hash(obj)
+
+    def __file_handler(self, path: Path, *, full_hash: bool = True):
+        # HASH(b"file" || file.content)
+        obj = path
+        if not full_hash:
+            obj = path.name.encode("utf-8")
+
+        content_hash = self.hash(obj)
+        obj = EntryType.file.value + content_hash
+        return self.hash(obj)
+
+    def get_digest(self, path: Path, *, full_hash: bool = True) -> bytes:
+        # check if the symlink itself was changed
+        if path.is_symlink():
+            return self.__symlink_handler(path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"path {path} does not exist")
+
+        # check if the file was changed
+        if path.is_file():
+            return self.__file_handler(path, full_hash=full_hash)
+
+        if not path.is_dir():
+            raise NotImplementedError(f"Unsupported file type: {path}")
+
+        # check if the directory was changed.
+        children = []
+        for entry in os.scandir(path):
+            name = entry.name
+            encoded_name = name.encode("utf-8")
+
+            entry_path = Path(entry.path)
+
+            if entry.is_symlink():
+                child_hash = self.__symlink_handler(entry_path)
+            elif entry.is_file(follow_symlinks=False):
+                child_hash = self.__file_handler(entry_path, full_hash=full_hash)
+            elif entry.is_dir(follow_symlinks=False):
+                child_hash = self.get_digest(entry_path, full_hash=full_hash)
+            else:
+                raise NotImplementedError(f"Unsupported file type: {entry.path}")
+
+            children.append((encoded_name, name, child_hash))
+
+        # sort entry items according to its utf-8 byte order
+        children.sort(key=lambda x: x[0])
+
+        # HASH(b"directory" || serialized children records)
+        buf = bytearray()
+        buf.extend(EntryType.directory.value)
+        for _, name, child_hash in children:
+            buf.extend(self.__pack_record(child_hash, name))
+
+        return self.hash(buf)

--- a/core/components/http_dependency.py
+++ b/core/components/http_dependency.py
@@ -1,10 +1,28 @@
 # Copyright 2024 The Lynx Authors. All rights reserved.
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
+import logging
+from enum import Enum
+from pathlib import Path
 
+from core.common.file_stamp import FileStamp
+from core.common.hash_tree import HashTree
 from core.components.component import Component
+from core.config_storage import ConfigStorage
 from core.fetchers.http_fetcher import HttpFetcher
+from core.settings import USER_CONFIG_STORAGE_PATH
 from core.utils import is_http_url
+
+
+class CheckMode(Enum):
+    """
+    This enum is used to identify HttpDependency.up_to_date() check mode.
+    - FAST: hash the structure of target_dir.
+    - STRICT: hash the structure of target_dir and the detailed file content.
+    """
+
+    FAST = "fast"
+    STRICT = "strict"
 
 
 class HttpDependency(Component):
@@ -19,6 +37,89 @@ class HttpDependency(Component):
     source_attributes = ["url"]
     source_stamp_attributes = ["url"]
 
+    _up_to_date = None
+    _check_mode = CheckMode.FAST
+
     def __init__(self, *args, **kwargs):
         super(HttpDependency, self).__init__(*args, **kwargs)
         self.fetcher = HttpFetcher(self)
+
+        check_mode = ConfigStorage(USER_CONFIG_STORAGE_PATH).get(
+            "http_dep.check_mode", default=CheckMode.FAST
+        )
+        if check_mode:
+            self._check_mode = CheckMode(check_mode)
+
+    def __create_file_stamp(self, type: str, name: str, target_dir: Path) -> FileStamp:
+        extra = {
+            "url": self.url,
+            "decompress": getattr(self, "decompress", True),
+            "paths": getattr(self, "paths", []),
+        }
+        return FileStamp(type, name, target_dir, extra=extra)
+
+    def on_fetched(self, root_dir, options):
+        super().on_fetched(root_dir, options)
+
+        if self._up_to_date or options.force:
+            return
+
+        target_dir = Path(self.target_dir)
+        stamp = self.__create_file_stamp(self.type, self.name, target_dir)
+        tree = HashTree()
+        fast_digest = tree.get_hex_digest(target_dir, full_hash=False)
+
+        full_digest = None
+        if self._check_mode == CheckMode.STRICT:
+            full_digest = tree.get_hex_digest(target_dir, full_hash=True)
+
+        stamp.write(fast_digest, full_digest)
+
+    def up_to_date(self):
+        target_dir = Path(self.target_dir)
+        if not target_dir.exists():
+            return False
+
+        stamp = self.__create_file_stamp(self.type, self.name, target_dir)
+        if not stamp.exists():
+            logging.debug(f"File stamp does not exist: {stamp.stamp_path}")
+            return False
+
+        stamp_info = stamp.read()
+        stamp_version = stamp_info.get("version", None)
+        # stamp version mismatched
+        if stamp_version != FileStamp.version:
+            logging.debug(
+                f"File stamp's version does not match: expected {FileStamp.version} but got {stamp_version}"
+            )
+            return False
+
+        tree = HashTree()
+        stamp_fast_digest = stamp_info.get("fast_digest", None)
+        fast_digest = tree.get_hex_digest(target_dir, full_hash=False)
+        if fast_digest != stamp_fast_digest:
+            logging.debug(
+                f"digest does not match: expected {fast_digest} but got {stamp_fast_digest}"
+            )
+            return False
+
+        if self._check_mode == CheckMode.FAST:
+            logging.info(
+                f"Skip {self.name} because it is already up to date according to a fast hash"
+            )
+            self._up_to_date = True
+            return True
+
+        stamp_full_digest = stamp_info.get("full_digest", None)
+        full_digest = tree.get_hex_digest(target_dir, full_hash=True)
+        if full_digest != stamp_full_digest:
+            logging.debug(
+                f"full digest does not match: expected {full_digest} but got {stamp_full_digest}"
+            )
+            return False
+
+        logging.info(
+            f"Skip {self.name} because it is already up to date according to a strict hash"
+        )
+        self._up_to_date = True
+        return True

--- a/core/config_storage.py
+++ b/core/config_storage.py
@@ -11,17 +11,21 @@ from core.exceptions import HabitatException
 class ConfigStorage(KeyValueStorage):
 
     def get(self, key, default=None):
-        value = (
-            os.environ.get("HABITAT_" + key.upper().replace(".", "_"))
-            or default
-            or super(ConfigStorage, self).get(key)
-            or NotSet
+        env_key = "HABITAT_" + key.upper().replace(".", "_")
+        env_value = os.environ.get(env_key)
+        if env_value is not None:
+            return env_value
+
+        value = super(ConfigStorage, self).get(key)
+        if value is not NotSet:
+            return value
+
+        if default is not None:
+            return default
+
+        raise HabitatException(
+            f'Configuration {key} not found, please run "hab setup {key}" to setup a correct value'
         )
-        if value is NotSet:
-            raise HabitatException(
-                f'Configuration {key} not found, please run "hab setup {key}" to setup a correct value'
-            )
-        return value
 
     def __iter__(self):
         config = self.data

--- a/core/fetchers/http_fetcher.py
+++ b/core/fetchers/http_fetcher.py
@@ -39,6 +39,8 @@ def get_digest(path: Union[str, Path]):
 
 
 def check_sha256(path: str, sha256: str):
+    if not sha256:
+        return False
     return get_digest(path) == sha256
 
 
@@ -108,14 +110,11 @@ def move_to_target_dir(temp_dir, target_dir, is_single_file):
     shutil.move(path, target_dir)
 
 
-def check_target_dir_existence(target_dir: str, override_exist: bool):
+def prepare_target_dir(target_dir: str):
     # target_dir's parent directory should be existed.
     os.makedirs(os.path.dirname(target_dir), exist_ok=True)
     if not os.path.exists(target_dir):
         pass
-    elif not override_exist:
-        logging.info(f"{target_dir} existed, skip fetching.")
-        return
     elif os.path.isdir(target_dir):
         logging.debug(f"directory {target_dir} is going to be overridden")
         _rmtree(target_dir)
@@ -140,17 +139,12 @@ class HttpFetcher(Fetcher):
             self._download_client = HttpxClient(self.base_url, getattr(self.component, "http_headers", {}))
         return self._download_client
 
-    async def download(self, item: str, root_dir: str, override_exist: bool):
-        logging.info(
-            f"{item} will be downloaded to path: {root_dir}, "
-            f'the operation will {"not " if not override_exist else ""}override existing file.'
-        )
-
+    async def download(self, item: str, root_dir: str):
         target_dir = os.path.join(root_dir, item)
         target_dir = str(Path(target_dir))
         component = self.component
         is_single_file = not getattr(component, "decompress", True)
-        check_target_dir_existence(target_dir, override_exist)
+        prepare_target_dir(target_dir)
 
         # update download url to get file name
         self._update_download_url(self.component.url)
@@ -340,5 +334,5 @@ class HttpFetcher(Fetcher):
             cache_path_handler=convert_url_to_cache_path
         )
 
-        await self.download(component.name, root_dir, options.force)
+        await self.download(component.name, root_dir)
         return [target_dir]

--- a/tests/test_hash_tree.py
+++ b/tests/test_hash_tree.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from core.common.hash_tree import HashTree
+from utils import generate_random_string
+
+
+def test_merkle_tree(tmp_path: Path):
+    root = tmp_path
+
+    # directories
+    sub_dir_a = tmp_path / "sub_dir_a"
+    sub_dir_a_1 = tmp_path / "sub_dir_a" / "1"
+    sub_dir_a_2 = tmp_path / "sub_dir_a" / "2"
+    sub_dir_b = tmp_path / "sub_dir_b"
+
+    for dir in [sub_dir_a, sub_dir_a_1, sub_dir_a_2, sub_dir_b]:
+        dir.mkdir(parents=True, exist_ok=True)
+
+    # files
+    sub_dir_a_hello = sub_dir_a / "hello"
+    sub_dir_a_world = sub_dir_a / "world"
+    sub_dir_a_1_foo = sub_dir_a_1 / "foo"
+    sub_dir_a_1_bar = sub_dir_a_1 / "bar"
+    sub_dir_a_1_2k = sub_dir_a_1 / "2k"
+
+    for file in [
+        sub_dir_a_hello,
+        sub_dir_a_world,
+        sub_dir_a_1_foo,
+        sub_dir_a_1_bar,
+        sub_dir_a_1_2k,
+    ]:
+        file.write_text(generate_random_string())
+
+    # symlink
+    sub_dir_b_broken_link = sub_dir_b / "broken_link"
+    sub_dir_b_broken_link.symlink_to(Path("non-existent"))
+    sub_dir_b_link = sub_dir_b / "link"
+    sub_dir_b_link.symlink_to(sub_dir_a_1_2k)
+
+    tree = HashTree()
+    original_fast_hash = tree.get_hex_digest(root, full_hash=False)
+    original_full_hash = tree.get_hex_digest(root, full_hash=True)
+
+    # modify sub_dir_a_1_2k, full hash should differ.
+    original_2k_content = sub_dir_a_1_2k.read_text()
+    sub_dir_a_1_2k.write_text(generate_random_string())
+    fast_hash_1 = tree.get_hex_digest(root, full_hash=False)
+    full_hash_1 = tree.get_hex_digest(root, full_hash=True)
+    assert fast_hash_1 == original_fast_hash
+    assert full_hash_1 != original_full_hash
+    sub_dir_a_1_2k.write_text(original_2k_content)
+
+    # remove sub_dir_a_2, fast hash should differ.
+    sub_dir_a_2.rmdir()
+    fast_hash_2 = tree.get_hex_digest(root, full_hash=False)
+    assert fast_hash_2 != original_fast_hash
+    sub_dir_a_2.mkdir()
+
+    # modify link, fast hash should differ.
+    sub_dir_b_link.unlink()
+    sub_dir_b_link.symlink_to(sub_dir_b_broken_link)
+    fast_hash_3 = tree.get_hex_digest(root, full_hash=False)
+    assert fast_hash_3 != original_fast_hash
+    sub_dir_b_link.unlink()
+    sub_dir_b_link.symlink_to(sub_dir_a_1_2k)
+
+    # all changes recoverd, all hash should be the same.
+    final_fast_hash = tree.get_hex_digest(root, full_hash=False)
+    final_full_hash = tree.get_hex_digest(root, full_hash=True)
+
+    assert final_fast_hash == original_fast_hash
+    assert final_full_hash == original_full_hash

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import hashlib
 import os
+import random
+import string
 import subprocess
 import sys
 from io import BytesIO
@@ -53,3 +55,9 @@ def make_change_in_repo(
 
 def generate_habitat_config_file(config_name: str, config):
     return f"{config_name}={str(config)}"
+
+
+def generate_random_string(max_length: int = 64) -> str:
+    length = random.randint(1, max_length)
+    s = "".join(random.choices(string.ascii_letters + string.digits, k=length))
+    return s


### PR DESCRIPTION
Implement http dependency status check.

Changes:

1. Introduce FileStamp module:
  - Write dependency status to a stamp file
  - The stamp key includes some selected fields of the dependency

2. Introduce MerkleTree module:
  - Calculate directory structure digest in fast mode
  - Calculate directory structure and file content in strict mode

3. Fix ConfigStorage default value handling.

4. Modify HttpFetcher default behavior:
  - Skip sha256 calculation if sha256 is not specified
  - Overwrite existing directory by default