### PR TITLE
feat: make up_to_date check async

### DIFF
--- a/core/common/hash_tree.py
+++ b/core/common/hash_tree.py
@@ -6,6 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, ClassVar, Union
 
+from core.utils import to_thread
+
 
 class CheckMode(Enum):
     """
@@ -77,6 +79,10 @@ class HashTree:
 
     def get_hex_digest(self, path: Path, *, full_hash: bool = True) -> str:
         return self.get_digest(path, full_hash=full_hash).hex()
+
+    async def async_get_hex_digest(self, path: Path, *, full_hash: bool = True) -> str:
+        digest = await to_thread(self.get_digest, path, full_hash=full_hash)
+        return digest.hex()
 
     def __symlink_handler(self, path: Path):
         # HASH(b"symlink" || symlink.target)

--- a/core/components/action_dependency.py
+++ b/core/components/action_dependency.py
@@ -152,6 +152,6 @@ class ActionDependency(Component):
             if hasattr(self, "parent") and self.parent:
                 self.parent.produce_event(self.name)
 
-    def up_to_date(self):
+    async def up_to_date(self):
         # action should never be cached
         return False

--- a/core/components/component.py
+++ b/core/components/component.py
@@ -154,7 +154,7 @@ class Component(ABC):
     def on_fetched(self, root_dir, options):
         self.fetched = True
 
-    def up_to_date(self):
+    async def up_to_date(self):
         return self.local_source_stamps.get(self.name) == self.source_stamp
 
     async def fetch(
@@ -177,7 +177,7 @@ class Component(ABC):
         try:
             ctx = observer.dependency_context(dep_name, dep_type)
             # TODO: up_to_date is deprecated, no cache detection here
-            needs_fetch = bool(options.force or not self.up_to_date())
+            needs_fetch = bool(options.force or not await self.up_to_date())
             with ctx:
                 if needs_fetch:
                     if tracer:

--- a/core/components/git_dependency.py
+++ b/core/components/git_dependency.py
@@ -8,7 +8,7 @@ from typing import Union
 
 from core.components.component import Component
 from core.fetchers.git_fetcher import GitFetcher
-from core.utils import get_patch_series, is_git_sha, is_git_url, is_repo_patched, is_repo_unchanged
+from core.utils import get_patch_series, is_git_sha, is_git_url, is_repo_patched, is_repo_unchanged, to_thread
 
 
 class GitDependency(Component):
@@ -43,7 +43,7 @@ class GitDependency(Component):
         super(GitDependency, self).__init__(*args, **kwargs)
         self.fetcher = GitFetcher(self)
 
-    def up_to_date(self):
+    async def up_to_date(self):
         target_dir = Path(self.target_dir)
         if not target_dir.exists():
             return False
@@ -54,15 +54,15 @@ class GitDependency(Component):
 
         patches = getattr(self, "patches", None)
         if not patches:
-            should_skip = is_repo_unchanged(target_commit, target_dir)
+            should_skip = await to_thread(is_repo_unchanged, target_commit, target_dir)
         elif isinstance(patches, str):
             patch_series = get_patch_series(patches)
-            should_skip = is_repo_patched(target_commit, patch_series, target_dir)
+            should_skip = await to_thread(is_repo_patched, target_commit, patch_series, target_dir)
         elif isinstance(patches, list):
             patch_series = []
             for p in patches:
                 patch_series.extend(get_patch_series(p))
-            should_skip = is_repo_patched(target_commit, patch_series, target_dir)
+            should_skip = await to_thread(is_repo_patched, target_commit, patch_series, target_dir)
 
         if should_skip:
             logging.info(f"Skip {self.name} because it is already up to date")

--- a/core/components/http_dependency.py
+++ b/core/components/http_dependency.py
@@ -63,14 +63,14 @@ class HttpDependency(Component):
 
         stamp.write(fast_digest, full_digest)
 
-    def up_to_date(self):
+    async def up_to_date(self):
         target_dir = Path(self.target_dir)
         if not target_dir.exists():
             return False
 
         stamp = self.__create_file_stamp(self.type, self.name, target_dir)
         if not stamp.exists():
-            logging.debug(f"File stamp does not exist: {stamp.stamp_path}")
+            logging.debug(f"{self.name} file stamp does not exist: {stamp.stamp_path}")
             return False
 
         stamp_info = stamp.read()
@@ -78,16 +78,16 @@ class HttpDependency(Component):
         # stamp version mismatched
         if stamp_version != FileStamp.version:
             logging.debug(
-                f"File stamp's version does not match: expected {FileStamp.version} but got {stamp_version}"
+                f"{self.name} file stamp's version does not match: expected {FileStamp.version} but got {stamp_version}"
             )
             return False
 
         tree = HashTree()
         stamp_fast_digest = stamp_info.get("fast_digest", None)
-        fast_digest = tree.get_hex_digest(target_dir, full_hash=False)
+        fast_digest = await tree.async_get_hex_digest(target_dir, full_hash=False)
         if fast_digest != stamp_fast_digest:
             logging.debug(
-                f"digest does not match: expected {fast_digest} but got {stamp_fast_digest}"
+                f"{self.name} digest does not match: expected {fast_digest} but got {stamp_fast_digest}"
             )
             return False
 
@@ -99,10 +99,10 @@ class HttpDependency(Component):
             return True
 
         stamp_full_digest = stamp_info.get("full_digest", None)
-        full_digest = tree.get_hex_digest(target_dir, full_hash=True)
+        full_digest = await tree.async_get_hex_digest(target_dir, full_hash=True)
         if full_digest != stamp_full_digest:
             logging.debug(
-                f"full digest does not match: expected {full_digest} but got {stamp_full_digest}"
+                f"{self.name} full digest does not match: expected {full_digest} but got {stamp_full_digest}"
             )
             return False
 

--- a/core/components/solution.py
+++ b/core/components/solution.py
@@ -292,8 +292,8 @@ class Solution(DependencyGroup):
         ).hexdigest()
         store_entries_cache_to_git(deps_cache, root_dir=root_dir)
 
-    def up_to_date(self):
-        return is_git_sha(getattr(self, "commit", "")) and super().up_to_date()
+    async def up_to_date(self):
+        return is_git_sha(getattr(self, "commit", "")) and await super().up_to_date()
 
     async def fetch(
         self, root_dir, options, existing_sources=None, existing_targets=None

--- a/core/utils.py
+++ b/core/utils.py
@@ -743,7 +743,7 @@ def get_patch_id(_input, repo_dir: Path) -> list[str]:
             "Failed to get patch id",
             context={
                 "command": shlex.join(patch_id_command),
-                "working-directory": repo_dir,
+                "working-directory": str(repo_dir),
                 "stderr": stderr.decode(),
             },
         )
@@ -803,7 +803,7 @@ def is_repo_patched(base_commit: str, patch_series: list[str], repo_dir: Path) -
             f"Failed to get git log in {repo_dir}",
             context={
                 "command": shlex.join(log_command),
-                "working-directory": repo_dir,
+                "working-directory": str(repo_dir),
                 "stderr": log_stderr.decode(),
             },
         )
@@ -823,7 +823,7 @@ def is_repo_patched(base_commit: str, patch_series: list[str], repo_dir: Path) -
             cause=e,
             context={
                 "command": f"git rev-parse HEAD~{patch_count}",
-                "working-directory": repo_dir,
+                "working-directory": str(repo_dir),
                 "stderr": e.stderr.decode()
             }
         )


### PR DESCRIPTION
Changes:
1. Add "async_get_hex_digest" to HashTree.
2. Modify up_to_date signature to async.
3. Run up_to_date check asynchronously.
4. Fix error handling in some utility functions.