### PR TITLE
chore: release habitat 0.3.148

### DIFF
--- a/core/__version__.py
+++ b/core/__version__.py
@@ -2,6 +2,6 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
-VERSION = (0, 3, 147)
+VERSION = (0, 3, 148)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Changes:
1. Smarter caching, read-only cache support, and faster asynchronous up-to-date checks.
2. Git, HTTP, and solution dependencies now skip unnecessary fetching.
3. Fixed multi-target dependency merging and Git patch identity handling.
4. Force sync is no longer the default; CI must pass --force when required.
5. Added task lifecycle results so failed dependencies cause downstream tasks to be skipped.
6. Added structured JSONL logs, terminal summaries, and local Habitat statistics via --stat-output.
7. Moved the wrapper cache from ~/.habitat/bin to ~/.habitat_cache/hab.
8. Upgraded PEX to 2.20.4.