### PR TITLE
fix: include cache modules in Windows package

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -1,6 +1,7 @@
 $root = Join-Path -Path (Get-Location).Path -ChildPath "core"
 $core = Join-Path -Path $root -ChildPath "*.py"
 $commands = Join-Path -Path $root -ChildPath "commands\*.py"
+$cache = Join-Path -Path $root -ChildPath "cache\*.py"
 $common = Join-Path -Path $root -ChildPath "common\*.py"
 $components = Join-Path -Path $root -ChildPath "components\*.py"
 $fetchers = Join-Path -Path $root -ChildPath "fetchers\*.py"
@@ -11,6 +12,7 @@ pyinstaller -y -F -p . -n hab .\core\main.py `
     --hidden-import=httpx `
     --add-data=${core}:"core" `
     --add-data=${commands}:"core\commands" `
+    --add-data=${cache}:"core\cache" `
     --add-data=${common}:"core\common" `
     --add-data=${components}:"core\components" `
     --add-data=${fetchers}:"core\fetchers" `


### PR DESCRIPTION
Package core/cache with the PyInstaller executable so HTTP dependencies can load FileCache on Windows.

TEST: pytest tests/test_windows_package.py; 53 non-LFS tests; make isort_check lint
Assisted-by: Codex