### PR TITLE
fix: enable statistics generation on Windows

### DIFF
--- a/core/observe/stat_session.py
+++ b/core/observe/stat_session.py
@@ -134,8 +134,6 @@ class StatSession:
         self._warning_handler = _WarningCaptureHandler()
 
     def start(self):
-        if platform.system() not in ("Linux", "Darwin"):
-            raise RuntimeError("statistics generation currently supports Linux and macOS only")
         if self._started:
             return
 

--- a/tests/test_stat_session.py
+++ b/tests/test_stat_session.py
@@ -3,7 +3,6 @@ import logging
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
 
 from core.observe import observer
 from core.observe.stat_session import StatSession
@@ -131,13 +130,6 @@ class StatSessionTests(unittest.TestCase):
             metadata = _read_events(path)[0]
 
         self.assertEqual(metadata["project"], "example/target")
-
-    def test_rejects_statistics_generation_on_windows(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            with patch("core.observe.stat_session.platform.system", return_value="Windows"):
-                session = StatSession(os.path.join(tmp, "stats.jsonl"), [], "sync")
-                with self.assertRaisesRegex(RuntimeError, "Linux and macOS"):
-                    session.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- remove the Linux/macOS-only guard from Habitat statistics sessions
- allow the packaged Windows executable to generate the same JSONL artifact
- remove the obsolete test that asserted Windows was rejected

## Why

The statistics implementation uses platform-neutral file, logging, subprocess,
and timing APIs. The explicit platform check prevented Windows CI from using
`--stat-output` even after the Windows package included the required modules.

## Validation

- `python3 -m unittest tests.test_stat_session tests.test_main_logging -v`
- `python3 -m flake8 core/observe/stat_session.py tests/test_stat_session.py`
- `git diff --check`

The broader pytest suite cannot complete locally because existing test fixtures
invoke `python`, while this macOS environment only provides `python3`.

Substantial AI assistance was provided by Codex. The author reviewed and is
responsible for the change.
